### PR TITLE
Support for Apple Silicon (mps), torch 2.6 and Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
+# ComfyUI_Qwen2-VL-Instruct with Apple Silicon support
+
+This fork (from [71091a4](https://github.com/IuvenisSapiens/ComfyUI_Qwen2-VL-Instruct/commit/71091a4dbbefc76ef2059e0d99ee97c98e86e7ae)) incorporates the support of Apple Silicon (M1, M2, etc.) to ComfyUI_Qwen2-VL-Instruct.
+
+Code tested on MacBook Pro M1 Max 64GB RAM with torch nightly build `torch-2.6.0.dev20241225` and Python 3.12.7. (I have not tested extensively on video, ymmv, fixes are welcome.)
+
+### Major changes:
+
+- Added Image as input so you can use a **Load Image** or **Load Image List From Dir** node directly.
+- Replaced the unsupported decord (latest python version supported by eva-decord is 3.11<sup>§</sup>) with python-opencv.
+- Removed non-applicable `auto-gptq` module so setup would work without error.
+- Obtain and set GPU device from ComfyUI instead of hardcoded to mps. It will be set correctly to 'mps' if your ComfyUI is running on Apple Silicon Macs.
+- Added a System prompt to Qwen. It will be handy if you are running an _abliterated_ model ;-)
+- Allow one to specify the Flash Attention model from the node. ** Note** Only "eager" will work on the Apple Silicon for now<sup>§</sup>.
+
+§ Notes on torch and python versions:
+
+* [Eva-decord](https://pypi.org/project/eva-decord/) is a fork of [decord](https://pypi.org/project/decord/) that supports ffmpeg5 and builds/installs on newer macos versions. However, eva-decord is no longer available for Python version above 3.11.
+
+* Somehow, (incompatibility with later PyTorch?) the following error occurs when doing inference on PyTorch version above 2.4:
+
+   `IndexError: Dimension out of range (expected to be in range of [-3, 2], but got 3)`
+
+    Setting the attention mode to "eager" solved the problem. If you are using torch 2.4 or below,the original "sdpa" would work just fine.
+
+
+# Original README
+
 # ComfyUI_Qwen2-VL-Instruct
 
 This is an implementation of [Qwen2-VL-Instruct](https://github.com/QwenLM/Qwen2-VL) by [ComfyUI](https://github.com/comfyanonymous/ComfyUI), which includes, but is not limited to, support for text-based queries, video queries, single-image queries, and multi-image queries to generate captions or responses.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ Code tested on MacBook Pro M1 Max 64GB RAM with torch nightly build `torch-2.6.0
 
     Setting the attention mode to "eager" solved the problem. If you are using torch 2.4 or below,the original "sdpa" would work just fine.
 
+## Installation
+
+If you have already have the original repository installed, remove it first.
+
+Either install from the ComfyUI Manager using *Install via Git URL* and enter the URL of this repository, or,
+
+Download or git clone this repository into the `ComfyUI/custom_nodes/` directory, then install the python packages in your ComfyUI Python environment:
+
+```bash
+cd ComfyUI/custom_nodes/
+git clone git@github.com:edwios/ComfyUI_Qwen2-VL-Instruct.git
+cd ComfyUI_Qwen2-VL-Instruct
+pip install -r requirements.txt
+```
+**Restart ComfyUI** when installation is done and successful.
 
 # Original README
 

--- a/path_nodes.py
+++ b/path_nodes.py
@@ -1,4 +1,4 @@
-from decord import VideoReader, cpu  # pip install decord
+import cv2
 class MultiplePathsInput:
     @classmethod
     def INPUT_TYPES(s):
@@ -29,16 +29,25 @@ with the **inputcount** and clicking update.
             return {"type": "image", "image": f"{file_path}"}
         elif ext in ["mp4", "mkv", "mov", "avi", "flv", "wmv", "webm", "m4v"]:
             print("source_video_path:", file_path)
-            vr = VideoReader(file_path, ctx=cpu(0))
+            #vr = VideoReader(file_path, ctx=cpu(0))
+            vidObj = cv2.VideoCapture(file_path)
+            vr=[]
+            while vidObj.isOpened():
+                ret, frame = vidObj.read()
+                if not ret:
+                    break
+                else:
+                    vr.append(frame)
             total_frames = len(vr) + 1
             print("Total frames:", total_frames)
-            avg_fps = vr.get_avg_fps()
+            avg_fps = vidObj.get_avg_fps()
             print("Get average FPS(frame per second):", avg_fps)
             duration = len(vr) / avg_fps
             print("Total duration:", duration, "seconds")
             width = vr[0].shape[1]
             height = vr[0].shape[0]
             print("Video resolution(width x height):", width, "x", height)
+            vidObj.release()
             return {
                 "type": "video",
                 "video": f"{file_path}",

--- a/path_nodes.py
+++ b/path_nodes.py
@@ -40,7 +40,7 @@ with the **inputcount** and clicking update.
                     vr.append(frame)
             total_frames = len(vr) + 1
             print("Total frames:", total_frames)
-            avg_fps = vidObj.get_avg_fps()
+            avg_fps = vidObj.get(cv2.CAP_PROP_FPS)
             print("Get average FPS(frame per second):", avg_fps)
             duration = len(vr) / avg_fps
             print("Total duration:", duration, "seconds")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ComfyUI_Qwen2-VL-Instruct"
 description = "This is an implementation of [Qwen2-VL-Instruct](https://github.com/QwenLM/Qwen2-VL) by [ComfyUI](https://github.com/comfyanonymous/ComfyUI), which includes, but is not limited to, support for text-based queries, video queries, single-image queries, and multi-image queries to generate captions or responses."
 version = "1.0.0"
 license = "LICENSE"
-dependencies = ["torch", "torchvision", "numpy", "pillow", "huggingface_hub", "transformers", "decord", "bitsandbytes","accelerate","qwen-vl-utils","optimum","av"]
+dependencies = ["torch", "torchvision", "numpy", "pillow", "huggingface_hub", "transformers", "bitsandbytes","accelerate","qwen-vl-utils","optimum","av", "opencv-python"]
 
 [project.urls]
 Repository = "https://github.com/IuvenisSapiens/ComfyUI_Qwen2-VL-Instruct"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,9 @@ torchaudio
 numpy
 pillow
 huggingface_hub
-decord
 accelerate
-qwen-vl-utils[decord]
 optimum
 av
-decord
-auto-gptq 
 transformers>=4.45.0
+qwen-vl-utils
+opencv-python


### PR DESCRIPTION
### Major changes:

- Added Image as input so you can use a **Load Image** or **Load Image List From Dir** node directly.
- Replaced the unsupported decord (latest python version supported by eva-decord is 3.11<sup>§</sup>) with python-opencv.
- Removed non-applicable `auto-gptq` module so setup would work without error.
- Obtain and set GPU device from ComfyUI instead of hardcoded to mps. It will be set correctly to 'mps' if your ComfyUI is running on Apple Silicon Macs.
- Added a System prompt to Qwen. It will be handy if you are running an _abliterated_ model ;-)
- Allow one to specify the Flash Attention model from the node. ** Note** Only "eager" will work on the Apple Silicon for now<sup>§</sup>.

Code tested on MacBook Pro M1 Max 64GB RAM with torch nightly build `torch-2.6.0.dev20241225` and Python 3.12.7. (I have not tested extensively on video, ymmv, fixes are welcome.)

### § Notes on torch and python versions:

* [Eva-decord](https://pypi.org/project/eva-decord/) is a fork of [decord](https://pypi.org/project/decord/) that supports ffmpeg5 and builds/installs on newer macos versions. However, eva-decord is no longer available for Python version above 3.11.

* Somehow, (incompatibility with later PyTorch?) the following error occurs when doing inference on PyTorch version above 2.4:

   `IndexError: Dimension out of range (expected to be in range of [-3, 2], but got 3)`

    Setting the attention mode to "eager" solved the problem. If you are using torch 2.4 or below,the original "sdpa" would work just fine.
